### PR TITLE
Render heading & description within question forms

### DIFF
--- a/src/components/SurveyShow/index.tsx
+++ b/src/components/SurveyShow/index.tsx
@@ -133,7 +133,9 @@ export const SurveyShow = (): JSX.Element | null => {
         </>
         :
         <>
+          <p>{currentQuestion.heading}</p>
           <p>{currentQuestion.prompt}</p>
+          <p>{currentQuestion.description}</p>
 
           {renderQuestion(currentQuestion)}
 

--- a/src/graphql/queries/GetSurveyResponse.ts
+++ b/src/graphql/queries/GetSurveyResponse.ts
@@ -9,7 +9,9 @@ export const GetSurveyResponseQuery = gql`
         name
         questions {
           id
+          heading
           prompt
+          description
           type
           options {
             id

--- a/src/graphql/queries/__generated__/GetSurveyResponse.ts
+++ b/src/graphql/queries/__generated__/GetSurveyResponse.ts
@@ -18,7 +18,9 @@ export interface GetSurveyResponse_surveyResponse_survey_questions_options {
 export interface GetSurveyResponse_surveyResponse_survey_questions {
   __typename: "Question";
   id: string;
+  heading: string | null;
   prompt: string;
+  description: string | null;
   type: string;
   options: GetSurveyResponse_surveyResponse_survey_questions_options[] | null;
 }


### PR DESCRIPTION
Resolves #73 

### Description

Shows the `description` and `heading` within the question forms

### Type of change

- New feature (non-breaking change which adds functionality)

### Screenshots

<img width="335" alt="Screen Shot 2021-11-25 at 11 59 07 AM" src="https://user-images.githubusercontent.com/12770108/143480153-ace5e3dc-a76c-4e62-abc3-99b30c5f68da.png">

<img width="324" alt="Screen Shot 2021-11-25 at 11 59 14 AM" src="https://user-images.githubusercontent.com/12770108/143480156-edb705d1-ae53-4564-89d9-804e95d364da.png">

<img width="335" alt="Screen Shot 2021-11-25 at 11 59 21 AM" src="https://user-images.githubusercontent.com/12770108/143480160-280a2714-d2e9-476a-988a-be3f38cde14b.png">


